### PR TITLE
Cleanup partial files on `KeyboardInterrupt`

### DIFF
--- a/clipper.py
+++ b/clipper.py
@@ -309,6 +309,8 @@ if __name__ == "__main__":
                         remove(fullpath)
                     sys.exit("Exiting...")
                 except Exception as e:
+                    if isfile(fullpath):
+                        remove(fullpath)
                     failed += 1
                     print(e)
                     if not isfile(base_path + "failed.txt"):

--- a/clipper.py
+++ b/clipper.py
@@ -304,9 +304,10 @@ if __name__ == "__main__":
                         upload.Upload()
                         remove(fullpath)
                     print()
-                except KeyboardInterrupt as e:
-                    remove(fullpath)
-                    raise e
+                except KeyboardInterrupt:
+                    if isfile(fullpath):
+                        remove(fullpath)
+                    sys.exit("Exiting...")
                 except Exception as e:
                     failed += 1
                     print(e)

--- a/clipper.py
+++ b/clipper.py
@@ -198,6 +198,7 @@ if __name__ == "__main__":
         Include the quotation marks and curly brackets!"""
         raise FileNotFoundError(e_msg)
 
+    failed = 0
     game_ids = {}
     b_ids = {}
     start = None
@@ -303,7 +304,11 @@ if __name__ == "__main__":
                         upload.Upload()
                         remove(fullpath)
                     print()
+                except KeyboardInterrupt as e:
+                    remove(fullpath)
+                    raise e
                 except Exception as e:
+                    failed += 1
                     print(e)
                     if not isfile(base_path + "failed.txt"):
                         with open("failed.txt", "w"):
@@ -313,3 +318,7 @@ if __name__ == "__main__":
                     print(file_name + ": FAILED!")
 
         start += timedelta(days=1)
+
+    if failed:
+        print(f"\n{str(failed)} clips not downloaded!"
+              " Check failed.txt and try downloading them manually.")


### PR DESCRIPTION
When a `KeyboardInterrupt` is caught during a download, the downloaded clip is deleted, since it will likely be a partial file.
Closes #5 
Edit: Also tracks number of failed downloads and prints a warning if at least one clip failed to download.